### PR TITLE
Allow nullable property that includes allOf

### DIFF
--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -8,6 +8,11 @@ class OpenAPIParser::SchemaValidator
       # if any schema return error, it's not valida all of value
       remaining_keys               = value.kind_of?(Hash) ? value.keys : []
       nested_additional_properties = false
+
+      if value.nil? && schema.nullable
+        return [value, nil]
+      end
+
       schema.all_of.each do |s|
         # We need to store the reference to all of, so we can perform strict check on allowed properties
         _coerced, err = validatable.validate_schema(value, s, :parent_all_of => true)

--- a/spec/data/petstore-with-discriminator.yaml
+++ b/spec/data/petstore-with-discriminator.yaml
@@ -182,6 +182,17 @@ components:
           anyOf:
             - "$ref": "#/components/schemas/DonatelloStyle"
             - "$ref": "#/components/schemas/MichelangeloStyle"
+        image:
+          allOf:
+            - "$ref": "#/components/schemas/Image"
+          nullable: true
+    Image:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
     DonatelloStyle:
       type: object
       nullable: true

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -150,6 +150,26 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
         request_operation.validate_request_body(content_type, body)
       end
 
+      it 'passing when sending nil to nullable property that includes allOf' do
+        body = {
+            "baskets" => [
+                {
+                    "name"    => "turtles",
+                    "content" => [
+                        {
+                            "name"                  => "Mr. Cat",
+                            "born_at"               => "2019-05-16T11:37:02.160Z",
+                            "description"           => "Cat gentleman",
+                            "image"                 => nil,
+                        }
+                    ]
+                },
+            ]
+        }
+
+        request_operation.validate_request_body(content_type, body)
+      end
+
       it 'throws error when unknown attribute nested in allOf' do
         body = {
             "baskets" => [


### PR DESCRIPTION
Hi there 👋 we've recently started using your gem and have an OpenAPI component defined like this

```yaml
components:
  schemas:    
    Image:
      type: object
      required:
        - id
        - url
      properties:
        id:
          type: string
        url:
          type: string
```

Then in other components `Image` can be nullable and in others not. So we're trying to define our schema like this where it is nullable:

```yaml
components:
  schemas:   
    User:
      type: object
      required:
        - image
      properties:
        image:
          allOf:
            - $ref: '#/components/schemas/Image'
          nullable: true
```

And like this where it isn't nullable

```yaml
components:
  schemas:   
    Pet:
      type: object
      required:
        - image
      properties:
        image:
          $ref: '#/components/schemas/Image'
```

As far as we're aware this is valid OpenAPI 3.0 schema, unfortunately, it doesn't appear to work correctly with this gem.  

I noticed in your existing examples you solve this slightly differently. Within `optional_combat_style`:

https://github.com/ota42y/openapi_parser/blob/d17334a866b39fa197d324b9d321df2b03d469b6/spec/data/petstore-with-discriminator.yaml#L181-L184

[`DonatelloStyle`](https://github.com/ota42y/openapi_parser/blob/master/spec/data/petstore-with-discriminator.yaml#L187) and [`MichelangeloStyle`](https://github.com/ota42y/openapi_parser/blob/d17334a866b39fa197d324b9d321df2b03d469b6/spec/data/petstore-with-discriminator.yaml#L196) are both specified as `nullable` within the component. This then presents the inverse problem within `required_combat_style` where the default `nullable` has been "overwritten":

https://github.com/ota42y/openapi_parser/blob/d17334a866b39fa197d324b9d321df2b03d469b6/spec/data/petstore-with-discriminator.yaml#L174-L180

I wondered if you had any thoughts on our schema and would consider updated your gem to support it.

I'm pretty new around here so I don't know if I edited the correct example to test this change or if it should live somewhere else. I'm happy to apply any changes or suggestions you might have.

Thanks very much!
